### PR TITLE
update testnet dnsSeeds

### DIFF
--- a/core/src/main/java/org/litecoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/litecoinj/params/TestNet3Params.java
@@ -61,11 +61,9 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
         alertSigningKey = Utils.HEX.decode("04302390343f91cc401d56d68b123028bf52e5fca1939df127f63c6467cdf9c8e2c14b61104cf817d0b780da337893ecc4aaff1309e536162dabbdb45200ca2b0a");
 
         dnsSeeds = new String[] {
-                "testnet-seed.bitcoin.jonasschnelli.ch", // Jonas Schnelli
-                "seed.tbtc.petertodd.org",               // Peter Todd
-                "seed.testnet.bitcoin.sprovoost.nl",     // Sjors Provoost
-                "testnet-seed.bluematt.me",              // Matt Corallo
-                "bitcoin-testnet.bloqseeds.net",         // Bloq
+                "testnet-seed.litecointools.com",
+                "seed-b.litecoin.loshan.co.uk",
+                "dnsseed-testnet.thrasher.io",
         };
         addrSeeds = null;
         bip32HeaderP2PKHpub = 0x043587cf; // The 4 byte header that serializes in base58 to "tpub".


### PR DESCRIPTION
testnet DNS seeds updated based on 
https://github.com/litecoin-project/litecoin/blob/07fe91da4f5fdce165d7425b4bf8db681dd2930d/src/chainparams.cpp#L231-L233
